### PR TITLE
chore(ci): auto PR dev→main & auto-merge khi CI xanh

### DIFF
--- a/.github/workflows/auto-pr-dev-to-main.yml
+++ b/.github/workflows/auto-pr-dev-to-main.yml
@@ -1,0 +1,25 @@
+name: Auto PR dev→main
+
+on:
+  push:
+    branches: [dev]
+  schedule:
+    - cron: '0 9 * * *' # 16:00 GMT+7 hằng ngày
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create PR dev→main if not exists
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: dev
+          destination_branch: main
+          pr_title: 'chore: auto PR dev→main'
+          pr_body: 'Tự động tạo PR từ dev sang main khi có commit mới hoặc theo lịch cron.'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_allow_empty: false
+          pr_draft: false
+          pr_reviewer: ''

--- a/.github/workflows/merge-if-green.yml
+++ b/.github/workflows/merge-if-green.yml
@@ -1,0 +1,27 @@
+name: Auto Merge dev→main PR if CI green
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  merge-pr:
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto merge PR dev→main if CI green
+        uses: pascalgn/automerge-action@v0.16.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          merge_method: squash
+          title: 'chore: auto-merge dev→main (CI green)'
+          commit_message: 'Auto-merge PR dev→main khi CI xanh.'
+          labels: ''
+          branch: main
+          pull_request: true
+          merge_filter_author: ''
+          merge_filter_branch: dev

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ type Item = {
 - Pages deploy (`.github/workflows/pages.yml`): build trên `main` rồi deploy GitHub Pages.
 - Vite có cấu hình `base` để tương thích đường dẫn trên Pages.
 
+## 7) Tự động tạo PR dev→main & auto-merge khi CI xanh
+
+- Khi có commit mới lên nhánh `dev` hoặc đến 16:00 GMT+7 mỗi ngày, workflow sẽ tự động tạo Pull Request từ `dev` sang `main` nếu có thay đổi.
+- Khi workflow CI (`ci.yml`) chạy thành công trên PR dev→main, workflow sẽ tự động merge PR này vào `main` (nếu repo bật branch protection với required status check là CI).
+- Không cần thao tác thủ công, chỉ cần commit lên `dev` và đảm bảo CI xanh.
+
 ## 8) Liên kết quan trọng
 
 - Repository: https://github.com/nguyentancrypto-source/iconic-logistics-website


### PR DESCRIPTION
- Thêm workflow auto tạo PR dev→main khi có commit mới hoặc theo lịch 16:00 GMT+7\n- Thêm workflow tự động merge PR dev→main nếu CI xanh\n- Cập nhật README hướng dẫn cách hoạt động\n\n## Hướng dẫn\n- Khi có commit mới lên dev hoặc đến 16:00 GMT+7 mỗi ngày, workflow sẽ tự động tạo PR dev→main nếu có thay đổi.\n- Khi CI xanh trên PR dev→main, workflow sẽ tự động merge vào main (nếu bật branch protection với required status check là CI).