### PR TITLE
chore(lint): resolve eslint warnings/errors

### DIFF
--- a/core/ports/ItemRepository.ts
+++ b/core/ports/ItemRepository.ts
@@ -15,9 +15,9 @@ export type PagedResult<T> = {
   pageSize: number;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface ItemRepository {
+  // eslint-disable-next-line no-unused-vars
   list(query: ItemQuery): Promise<PagedResult<Item>>;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line no-unused-vars
   findById(id: string): Promise<Item | null>;
 }

--- a/src/interface/ErrorBoundary.tsx
+++ b/src/interface/ErrorBoundary.tsx
@@ -10,9 +10,11 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
   static getDerivedStateFromError(error: Error) {
     return { hasError: true, error };
   }
-  // eslint-disable-next-line class-methods-use-this
-  componentDidCatch(/* error: Error, info: React.ErrorInfo */) {
-    // Optionally log error
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // Optionally log error or send to monitoring
+    void error;
+    void info;
+    // console.error('ErrorBoundary caught:', error, info);
   }
   render() {
     if (this.state.hasError) {

--- a/src/interface/Items.test.tsx
+++ b/src/interface/Items.test.tsx
@@ -23,7 +23,7 @@ beforeEach(() => {
   ) as unknown as typeof fetch;
 });
 afterEach(() => {
-  (global.fetch as any).mockRestore?.();
+  vi.restoreAllMocks();
 });
 
 describe('Items', () => {


### PR DESCRIPTION
- ItemRepository: lint-safe params and inline directives
- ErrorBoundary: implement componentDidCatch with void usage
- Items.test: remove any cast, use vi.restoreAllMocks()

All tests pass locally; running CI to verify.