### PR TITLE
ci: fix auto-rebase action version from v1 to 1.12

### DIFF
--- a/.github/workflows/auto-rebase-ui-ux.yml
+++ b/.github/workflows/auto-rebase-ui-ux.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Rebase PR onto main
         if: github.event_name == 'pull_request'
-        uses: cirrus-actions/rebase@v1
+        uses: cirrus-actions/rebase@1.12
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Find open UI/UX PRs and trigger rebase


### PR DESCRIPTION
🐛 **Fix Auto Rebase workflow failure**

**Problem:**
- Auto Rebase UI/UX PRs workflow fails with error: `Unable to resolve action cirrus-actions/rebase@v1, unable to find version v1`
- This is blocking rebase operations for UI/UX branches

**Root Cause:**
- Workflow uses non-existent version `cirrus-actions/rebase@v1`
- The correct stable version is `cirrus-actions/rebase@1.12`

**Solution:**
- Update action version from `@v1` to `@1.12`
- This matches the version used successfully in other repositories

**Testing:**
- After merge, auto-rebase will work properly for UI/UX PRs
- No more workflow failures due to missing action version

**Impact:**
- ✅ Fixes Auto Rebase UI/UX PRs workflow
- ✅ Enables automatic rebasing for UI/UX branches  
- ✅ Removes CI noise from failed workflow runs